### PR TITLE
Allow for exempt users and roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ antispam(bot, {
   maxDuplicatesWarning: 7,// Maximum amount of duplicate messages a user can send in a timespan before getting warned
   maxDuplicatesBan: 10, // Maximum amount of duplicate messages a user can send in a timespan before getting banned
   deleteMessagesAfterBanForPastDays: 7 // Delete the spammed messages after banning for the past x days.
+  exemptRoles: ["Admin", "Chat Moderator"] // The names of the roles which should not be spam-filtered
+  exemptUsers: ["user#1234"] // The Discord tags of the users who should not be spam-filtered
 });
 
 ```

--- a/anti_spam.js
+++ b/anti_spam.js
@@ -19,11 +19,17 @@ module.exports = function (bot, options) {
   const maxDuplicatesWarning = (options && options.duplicates || 7);
   const maxDuplicatesBan = (options && options.duplicates || 10);
   const deleteMessagesAfterBanForPastDays = (options && options.deleteMessagesAfterBanForPastDays || 7);
+  const exemptRoles = (options && options.exemptRoles) || []
+  const exemptUsers = (options && options.exemptUsers) || []
 
   bot.on('message', msg => {
 
     //Always return with an bot.....
     if(msg.author.bot) return;
+
+    // Return immediately if user is exempt
+    if(msg.member && msg.member.roles.some(r => exemptRoles.includes(r.name))) return;
+    if(exemptUsers.includes(msg.author.tag)) return;
 
     if(msg.author.id != bot.user.id){
       var now = Math.floor(Date.now());


### PR DESCRIPTION
# Resolves
Resolves #13 

# Description of changes
Two new properties are added to the options object.
<table>
  <tr><th>Property Name</th><th>Type</th><th>Default Value</th><th>Description</th></tr>
  <tr><td>exemptUsers</td><td>array</td><td><code>[]</code></td><td>An array of the case-sensitive Discord tags of exempt users. A Discord tag is a username, a hashtag, and a 4-digit "discriminator" numeric code. If a user is exempt, the bot will ignore them: they won't be warned or banned.</td></tr>
  <tr><td>exemptRoles</td><td>array</td><td><code>[]</code></td><td>An array of the case-sensitive role names. A member of a guild with a role name as specified in this array will be considered exempt. If a user is exempt, the bot will ignore them: they won't be warned or banned</td></tr>
</table>

In addition, the `README.md` file is modified to reflect these changes, providing examples and commentary to help users understand which properties are allowed.

# Breaking Changes - None
**This pull request does not introduce breaking changes.**

Arrow functions were introduced in the same version of ECMAScript as the `const` keyword for declaring variables. This `const` keyword is already used in the repository; hence, using arrow functions (as is done by this pull request) will not bump the minimum Node version.

# Testing
Only manual testing was performed. All of them completed successfully.
- Incorrect or absent exempt roles did not stop the spam filter
- Correct exempt roles did stop the spam filter
- Incorrect or absent exempt usernames did not stop the spam filter
- Correct exempt roles did stop the spam filter
# Notes
These are some very minor observations
- There is no `LICENCE` file, but the package.json specifies a licence
- Sometimes double quotes are used for string literals, but other times double quotes are used
- The bot still detects spam inside its DMs, despite such spam causing little harm
- Filling the object with default values
 - Might be more readable with `Object.assign`
 - `(a && b || c)`, `(a && b) || c` mean the same thing, but the latter is more readable. This should be preferred for _all_ the default value assignments.
- Checking if the bot authored the message it's responding to is no longer needed, because it now ignores all bots (including itself) anyway.