### PR TITLE
Remove banned users array

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,7 +194,7 @@ class antiSpam extends Events.EventEmitter {
       this.emit("warnEmit", message.member);
     }
 
-    if (messageMatches === this.maxDuplicatesBan && !bannedUsers.includes(message.author.id)) {
+    if (messageMatches === this.maxDuplicatesBan) {
       banUser(message);
       this.emit("banEmit", message.member);
     }
@@ -211,7 +211,7 @@ class antiSpam extends Events.EventEmitter {
       this.emit("warnEmit", message.member);
     }
 
-    if (spamMatches === this.banThreshold && !bannedUsers.includes(message.author.id)) {
+    if (spamMatches === this.banThreshold) {
       banUser(message);
       this.emit("banEmit", message.member);
     }


### PR DESCRIPTION
Remove banned users array. Why? Because if a user is unbanned, and if he spam again, he will not be banned. I don't think that's great.
I left the array so that we could still know who is banned when we do `getData()`.