### PR TITLE
Pass member into ignoredUsers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,6 @@ import { EventEmitter } from 'events';
 import {
 	PermissionResolvable,
 	Snowflake,
-	User,
 	Guild,
 	TextChannel,
 	GuildMember,
@@ -66,7 +65,7 @@ declare module 'discord-anti-spam' {
 		exemptPermissions?: PermissionResolvable[];
 		ignoreBots?: boolean;
 		verbose?: boolean;
-		ignoredUsers?: Snowflake[] | ((user: User) => boolean);
+		ignoredUsers?: Snowflake[] | ((member: GuildMember) => boolean);
 		ignoredRoles?: (Snowflake | string)[] | ((role: Role) => boolean);
 		ignoredGuilds?: Snowflake[] | ((guild: Guild) => boolean);
 		ignoredChannels?: Snowflake[] | ((channel: TextChannel) => boolean);

--- a/index.js
+++ b/index.js
@@ -166,7 +166,7 @@ class AntiSpam extends EventEmitter {
 					: options.ignoredRoles.includes(role.id) || options.ignoredRoles.includes(role.name)
 			) ||
 			(typeof options.ignoredUsers === 'function'
-				? options.ignoredUsers(message.author)
+				? options.ignoredUsers(message.member)
 				: options.ignoredUsers.includes(message.author.id)) ||
 			(typeof options.ignoredGuilds === 'function'
 				? options.ignoredGuilds(message.guild)


### PR DESCRIPTION
This PR changes the ignoredUsers option to use a member instead of a user, allows for checking other things like nickname or server boosters