### PR TITLE
Changed filter for messageMatches

### DIFF
--- a/index.js
+++ b/index.js
@@ -285,7 +285,7 @@ class AntiSpam extends EventEmitter {
 		});
 
 		const messageMatches = data.messageCache.filter(
-			m => 	m.time > Date.now() - options.maxDuplicatesInterval &&
+			m => 	m.time > Date.now() - options.maxInterval &&
 					m.content === message.content &&
 					m.author === message.author.id
 		).length;


### PR DESCRIPTION
Change filter param so that it's checking the maxInterval option for non-duplicate spam matching. Before this change it would be checking the maxDuplicatesInterval for both spam matches and duplicate matches, which is wrong.