### PR TITLE
Update interval option

### DIFF
--- a/index.js
+++ b/index.js
@@ -290,7 +290,7 @@ class AntiSpam extends EventEmitter {
 					m.author === message.author.id
 		).length;
 		const spamMatches = data.messageCache.filter(
-			m => 	m.time > Date.now() - options.maxDuplicatesInterval &&
+			m => 	m.time > Date.now() - options.maxInterval &&
 					m.author === message.author.id
 		).length;
 


### PR DESCRIPTION
Updated the interval option check for non-duplicate messages. This makes it so that it works correctly for checking spam that is not duplicates. 