### PR TITLE
Having message.id saved in messageCache

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ declare module 'discord-anti-spam' {
 
 	type AntiSpamData = {
 		messageCache: {
-			message_id: string;
+			messageID: string;
 			content: string;
 			author: Snowflake;
 			time: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,6 +42,7 @@ declare module 'discord-anti-spam' {
 
 	type AntiSpamData = {
 		messageCache: {
+			message_id: string;
 			content: string;
 			author: Snowflake;
 			time: number;

--- a/index.js
+++ b/index.js
@@ -338,6 +338,7 @@ class AntiSpam extends EventEmitter {
 		};
 
 		data.messageCache.push({
+			message_id: message.id,
 			content: message.content,
 			author: message.author.id,
 			time: Date.now()

--- a/index.js
+++ b/index.js
@@ -338,7 +338,7 @@ class AntiSpam extends EventEmitter {
 		};
 
 		data.messageCache.push({
-			message_id: message.id,
+			messageID: message.id,
 			content: message.content,
 			author: message.author.id,
 			time: Date.now()


### PR DESCRIPTION
I find having the message.id in messageCache extremely useful. I understand it's an increase in memory, but this allows treatment not only for the message that triggered the threshold, but also the ones that contributed to it. If you want to delete the spam messages, and they are in different channels, you will only need to take the last x messages with the same author from messageCache as the one that triggered to threshold.