### PR TITLE
Fix the error: 'TypeError: Cannot read properties of undefined (reading 'id')'

### DIFF
--- a/index.js
+++ b/index.js
@@ -462,7 +462,7 @@ class AntiSpamClient extends EventEmitter {
 	 * });
 	 */
 	async message (message) {
-		const options = this.getOptions()
+		const options = this.getOptions(message.guild)
 
 		if (
 			!message.guild ||


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the error: 'TypeError: Cannot read properties of undefined (reading 'id')'


**Status and versioning classification:**

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
