### PR TITLE
docs: fix small typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ const antiSpam = new AntiSpam({
 }); // If a guild does not have any separate options, these are the settings they will be using.
 
 client.on("ready", () => antiSpam.addGuildOptions(client.guilds.fetch("583920432168828938"), {modLogsChannelName: "special-logs"}))
-client.on("messageCreate", (message) => antiSpam.message(messageCreate));
+client.on("messageCreate", (message) => antiSpam.message(message));
 client.login("YOUR_SUPER_SECRET_TOKEN");
 ```
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes a typo in README.md. It should me `message` not `messageCreate`

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
