### PR TITLE
Updating broken types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,8 +13,6 @@ import {
 	Role
 } from 'discord.js';
 declare module 'discord-anti-spam' {
-	const _default: AntiSpam;
-	export default _default;
 	class AntiSpam extends EventEmitter {
 		constructor(options?: AntiSpamOptions);
 		public options: AntiSpamOptions;
@@ -84,4 +82,6 @@ declare module 'discord-anti-spam' {
 		modLogsEnabled?: boolean;
 		removeMessages?: boolean;
 	};
+	
+	export default AntiSpam;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When I tried to use `discord-anti-spam` in my TypeScript Discord project, `tsc` is running into an error saying "Type 'AntiSpam' has no construct signatures. ts(2351)".

I had to change the source in `node_modules` to remove the warning.

This PR will remove the error.

**Status and versioning classification:**

This PR **only** includes non-code changes, like changes to documentation, README, etc.
